### PR TITLE
added jgen.close() in serialize()

### DIFF
--- a/src/main/java/com/github/fge/jsonpatch/JsonPatch.java
+++ b/src/main/java/com/github/fge/jsonpatch/JsonPatch.java
@@ -164,6 +164,7 @@ public final class JsonPatch
         for (final JsonPatchOperation op: operations)
             op.serialize(jgen, provider);
         jgen.writeEndArray();
+        jgen.close();
     }
 
     @Override


### PR DESCRIPTION
e.g.for a patch of '{a:1}' to '{a:2}', the patch is 
```
[{"op":"replace","path":"/a","value":2}]
```
without ``jgen.close()`` in ``serialize()``, it will print out:
```
[{"op":"replace","path":"/a","value":2
```

should jgen be closed inside serialize()? or outsider by the caller? 
please feel free to close and ignore this issue if it should be the later case. I can't say closing it inside serialize() is better, but probably will behave as people expect. thx